### PR TITLE
refactor: rename LayerContracts to Contracts across the codebase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "easy-http/layer-contracts",
+    "name": "easy-http/contracts",
     "description": "HTTP client adapter contracts for PHP applications",
     "type": "library",
     "license": "MIT",
@@ -31,12 +31,12 @@
     },
     "autoload": {
         "psr-4": {
-            "EasyHttp\\LayerContracts\\": "src/"
+            "EasyHttp\\Contracts\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "EasyHttp\\LayerContracts\\Tests\\": "tests/"
+            "EasyHttp\\Contracts\\Tests\\": "tests/"
         }
     }
 }

--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace EasyHttp\LayerContracts;
+namespace EasyHttp\Contracts;
 
-use EasyHttp\LayerContracts\Contracts\EasyClientContract;
-use EasyHttp\LayerContracts\Contracts\HttpClientAdapter;
-use EasyHttp\LayerContracts\Contracts\HttpClientRequest;
-use EasyHttp\LayerContracts\Contracts\HttpClientResponse;
+use EasyHttp\Contracts\Contracts\EasyClientContract;
+use EasyHttp\Contracts\Contracts\HttpClientAdapter;
+use EasyHttp\Contracts\Contracts\HttpClientRequest;
+use EasyHttp\Contracts\Contracts\HttpClientResponse;
 
 abstract class AbstractClient implements EasyClientContract
 {

--- a/src/Common/ClientRequest.php
+++ b/src/Common/ClientRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Common;
+namespace EasyHttp\Contracts\Common;
 
-use EasyHttp\LayerContracts\Contracts\HttpClientRequest;
-use EasyHttp\LayerContracts\Contracts\Request\HttpSecurityContext;
+use EasyHttp\Contracts\Contracts\HttpClientRequest;
+use EasyHttp\Contracts\Contracts\Request\HttpSecurityContext;
 
 class ClientRequest implements HttpClientRequest
 {

--- a/src/Common/SecurityContext.php
+++ b/src/Common/SecurityContext.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Common;
+namespace EasyHttp\Contracts\Common;
 
-use EasyHttp\LayerContracts\Contracts\Request\HttpSecurityContext;
+use EasyHttp\Contracts\Contracts\Request\HttpSecurityContext;
 
 class SecurityContext implements HttpSecurityContext
 {

--- a/src/Contracts/EasyClientContract.php
+++ b/src/Contracts/EasyClientContract.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Contracts;
+namespace EasyHttp\Contracts\Contracts;
 
 interface EasyClientContract
 {

--- a/src/Contracts/HttpClientAdapter.php
+++ b/src/Contracts/HttpClientAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Contracts;
+namespace EasyHttp\Contracts\Contracts;
 
-use EasyHttp\LayerContracts\Exceptions\HttpClientException;
+use EasyHttp\Contracts\Exceptions\HttpClientException;
 
 interface HttpClientAdapter
 {

--- a/src/Contracts/HttpClientRequest.php
+++ b/src/Contracts/HttpClientRequest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Contracts;
+namespace EasyHttp\Contracts\Contracts;
 
-use EasyHttp\LayerContracts\Contracts\Request\HttpSecurityContext;
+use EasyHttp\Contracts\Contracts\Request\HttpSecurityContext;
 
 interface HttpClientRequest
 {

--- a/src/Contracts/HttpClientResponse.php
+++ b/src/Contracts/HttpClientResponse.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Contracts;
+namespace EasyHttp\Contracts\Contracts;
 
-use EasyHttp\LayerContracts\Exceptions\ImpossibleToParseJsonException;
+use EasyHttp\Contracts\Exceptions\ImpossibleToParseJsonException;
 
 interface HttpClientResponse
 {

--- a/src/Contracts/Request/HttpSecurityContext.php
+++ b/src/Contracts/Request/HttpSecurityContext.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Contracts\Request;
+namespace EasyHttp\Contracts\Contracts\Request;
 
 interface HttpSecurityContext
 {

--- a/src/Exceptions/HttpClientException.php
+++ b/src/Exceptions/HttpClientException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Exceptions;
+namespace EasyHttp\Contracts\Exceptions;
 
 use Exception;
 

--- a/src/Exceptions/HttpConnectionException.php
+++ b/src/Exceptions/HttpConnectionException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Exceptions;
+namespace EasyHttp\Contracts\Exceptions;
 
 class HttpConnectionException extends HttpClientException
 {

--- a/src/Exceptions/ImpossibleToParseJsonException.php
+++ b/src/Exceptions/ImpossibleToParseJsonException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Exceptions;
+namespace EasyHttp\Contracts\Exceptions;
 
 use Exception;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Tests;
+namespace EasyHttp\Contracts\Tests;
 
 use Faker\Factory;
 use Faker\Generator;

--- a/tests/Unit/AbstractClientTest.php
+++ b/tests/Unit/AbstractClientTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Tests\Unit;
+namespace EasyHttp\Contracts\Tests\Unit;
 
-use EasyHttp\LayerContracts\Contracts\HttpClientResponse;
-use EasyHttp\LayerContracts\Exceptions\HttpClientException;
-use EasyHttp\LayerContracts\Exceptions\HttpConnectionException;
-use EasyHttp\LayerContracts\Exceptions\ImpossibleToParseJsonException;
-use EasyHttp\LayerContracts\Tests\Unit\Example\SomeClient;
+use EasyHttp\Contracts\Contracts\HttpClientResponse;
+use EasyHttp\Contracts\Exceptions\HttpClientException;
+use EasyHttp\Contracts\Exceptions\HttpConnectionException;
+use EasyHttp\Contracts\Exceptions\ImpossibleToParseJsonException;
+use EasyHttp\Contracts\Tests\Unit\Example\SomeClient;
 use PHPUnit\Framework\TestCase;
 
 class AbstractClientTest extends TestCase

--- a/tests/Unit/Common/ClientRequestSecurityTest.php
+++ b/tests/Unit/Common/ClientRequestSecurityTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Tests\Unit\Common;
+namespace EasyHttp\Contracts\Tests\Unit\Common;
 
-use EasyHttp\LayerContracts\Common\SecurityContext;
-use EasyHttp\LayerContracts\Tests\TestCase;
+use EasyHttp\Contracts\Common\SecurityContext;
+use EasyHttp\Contracts\Tests\TestCase;
 
 class ClientRequestSecurityTest extends TestCase
 {

--- a/tests/Unit/Common/ClientRequestTest.php
+++ b/tests/Unit/Common/ClientRequestTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Tests\Unit\Common;
+namespace EasyHttp\Contracts\Tests\Unit\Common;
 
-use EasyHttp\LayerContracts\Common\SecurityContext;
-use EasyHttp\LayerContracts\Tests\TestCase;
-use EasyHttp\LayerContracts\Tests\Unit\Example\ClientRequest;
+use EasyHttp\Contracts\Common\SecurityContext;
+use EasyHttp\Contracts\Tests\TestCase;
+use EasyHttp\Contracts\Tests\Unit\Example\ClientRequest;
 
 class ClientRequestTest extends TestCase
 {

--- a/tests/Unit/Example/ClientAdapter.php
+++ b/tests/Unit/Example/ClientAdapter.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Tests\Unit\Example;
+namespace EasyHttp\Contracts\Tests\Unit\Example;
 
-use EasyHttp\LayerContracts\Contracts\HttpClientAdapter;
-use EasyHttp\LayerContracts\Contracts\HttpClientRequest;
-use EasyHttp\LayerContracts\Contracts\HttpClientResponse;
+use EasyHttp\Contracts\Contracts\HttpClientAdapter;
+use EasyHttp\Contracts\Contracts\HttpClientRequest;
+use EasyHttp\Contracts\Contracts\HttpClientResponse;
 
 class ClientAdapter implements HttpClientAdapter
 {

--- a/tests/Unit/Example/ClientRequest.php
+++ b/tests/Unit/Example/ClientRequest.php
@@ -1,7 +1,7 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Tests\Unit\Example;
+namespace EasyHttp\Contracts\Tests\Unit\Example;
 
-class ClientRequest extends \EasyHttp\LayerContracts\Common\ClientRequest
+class ClientRequest extends \EasyHttp\Contracts\Common\ClientRequest
 {
 }

--- a/tests/Unit/Example/ClientResponse.php
+++ b/tests/Unit/Example/ClientResponse.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Tests\Unit\Example;
+namespace EasyHttp\Contracts\Tests\Unit\Example;
 
-use EasyHttp\LayerContracts\Contracts\HttpClientResponse;
+use EasyHttp\Contracts\Contracts\HttpClientResponse;
 
 class ClientResponse implements HttpClientResponse
 {

--- a/tests/Unit/Example/SomeClient.php
+++ b/tests/Unit/Example/SomeClient.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace EasyHttp\LayerContracts\Tests\Unit\Example;
+namespace EasyHttp\Contracts\Tests\Unit\Example;
 
-use EasyHttp\LayerContracts\AbstractClient;
-use EasyHttp\LayerContracts\Contracts\HttpClientAdapter;
-use EasyHttp\LayerContracts\Contracts\HttpClientRequest;
+use EasyHttp\Contracts\AbstractClient;
+use EasyHttp\Contracts\Contracts\HttpClientAdapter;
+use EasyHttp\Contracts\Contracts\HttpClientRequest;
 
 class SomeClient extends AbstractClient
 {


### PR DESCRIPTION
This pull request introduces a namespace refactoring for the `EasyHttp` library, simplifying and standardizing the naming conventions by removing the "LayerContracts" prefix. The changes affect the main library, tests, and associated files.