### PR TITLE
Refactor AbstractClient to use HTTPClientFactory for requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Standardized artifact names from `Http*` to `HTTP*`. ([#3](https://github.com/easy-http/contracts/pull/3))
 - Renamed `EasyClientContract` to `HTTPClientContract`. ([#4](https://github.com/easy-http/contracts/pull/4))
 - Renamed `ImpossibleToParseJsonException` to `HTTPJsonParseException`. ([#5](https://github.com/easy-http/contracts/pull/5))
+- Introduced `HTTPClientFactory` and refactored `AbstractClient` to create requests and adapters through factory methods. ([#6](https://github.com/easy-http/contracts/pull/6))
 
 ## [v2.0.0 (2025-06-15)](https://github.com/easy-http/contracts/tree/v2.0.0)
 

--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -10,10 +10,14 @@ use EasyHTTP\Contracts\Contracts\HTTPClientResponse;
 abstract class AbstractClient implements HTTPClientContract
 {
     protected HTTPClientAdapter $adapter;
-
     protected HTTPClientRequest $request;
-
+    protected HTTPClientFactory $factory;
     protected $handler;
+
+    public function __construct(HTTPClientFactory $factory)
+    {
+        $this->factory = $factory;
+    }
 
     public function getRequest(): HTTPClientRequest
     {
@@ -22,13 +26,13 @@ abstract class AbstractClient implements HTTPClientContract
 
     public function call(string $method, string $uri): HTTPClientResponse
     {
-        $request = $this->buildRequest($method, $uri);
+        $request = $this->factory->createRequest($method, $uri);
         return $this->getAdapter()->request($request);
     }
 
     public function prepareRequest(string $method, string $uri): HTTPClientRequest
     {
-        $this->request = $this->buildRequest($method, $uri);
+        $this->request = $this->factory->createRequest($method, $uri);
 
         return $this->request;
     }
@@ -52,7 +56,7 @@ abstract class AbstractClient implements HTTPClientContract
             return $this->adapter;
         }
 
-        $this->adapter = $this->buildAdapter();
+        $this->adapter = $this->factory->createAdapter($this->handler);
 
         return $this->adapter;
     }
@@ -71,7 +75,4 @@ abstract class AbstractClient implements HTTPClientContract
     {
         unset($this->adapter);
     }
-
-    abstract protected function buildRequest(string $method, string $uri): HTTPClientRequest;
-    abstract protected function buildAdapter(): HTTPClientAdapter;
 }

--- a/src/HTTPClientFactory.php
+++ b/src/HTTPClientFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace EasyHTTP\Contracts;
+
+use EasyHTTP\Contracts\Contracts\HTTPClientRequest;
+use EasyHTTP\Contracts\Contracts\HTTPClientAdapter;
+
+interface HTTPClientFactory
+{
+    public function createRequest(string $method, string $uri): HTTPClientRequest;
+    public function createAdapter(?callable $handler = null): HTTPClientAdapter;
+}

--- a/tests/Unit/Example/ClientFactory.php
+++ b/tests/Unit/Example/ClientFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace EasyHTTP\Contracts\Tests\Unit\Example;
+
+use EasyHTTP\Contracts\Contracts\HTTPClientAdapter;
+use EasyHTTP\Contracts\Contracts\HTTPClientRequest;
+use EasyHTTP\Contracts\HTTPClientFactory;
+
+class ClientFactory implements HTTPClientFactory
+{
+    private int $adapterCounter = 0;
+
+    public function getAdapterCounter(): int
+    {
+        return $this->adapterCounter;
+    }
+
+    public function createRequest(string $method, string $uri): HTTPClientRequest
+    {
+        return new ClientRequest($method, $uri);
+    }
+
+    public function createAdapter(?callable $handler = null): HTTPClientAdapter
+    {
+        $this->adapterCounter++;
+
+        $adapter = new ClientAdapter();
+
+        if ($handler !== null) {
+            $adapter->setHandler($handler);
+        }
+
+        return $adapter;
+    }
+}

--- a/tests/Unit/Example/SomeClient.php
+++ b/tests/Unit/Example/SomeClient.php
@@ -3,33 +3,19 @@
 namespace EasyHTTP\Contracts\Tests\Unit\Example;
 
 use EasyHTTP\Contracts\AbstractClient;
-use EasyHTTP\Contracts\Contracts\HTTPClientAdapter;
-use EasyHTTP\Contracts\Contracts\HTTPClientRequest;
 
 class SomeClient extends AbstractClient
 {
-    private int $adapterCounter = 0;
+    private ClientFactory $clientFactory;
+
+    public function __construct()
+    {
+        $this->clientFactory = new ClientFactory();
+        parent::__construct($this->clientFactory);
+    }
 
     public function getAdapterCounter(): int
     {
-        return $this->adapterCounter;
-    }
-
-    protected function buildRequest(string $method, string $uri): HTTPClientRequest
-    {
-        return new ClientRequest($method, $uri);
-    }
-
-    protected function buildAdapter(): HTTPClientAdapter
-    {
-        $this->adapterCounter++;
-
-        $client = new ClientAdapter();
-
-        if ($this->hasHandler()) {
-            $client->setHandler($this->handler);
-        }
-
-        return $client;
+        return $this->clientFactory->getAdapterCounter();
     }
 }


### PR DESCRIPTION
This pull request introduces a new `HTTPClientFactory` interface and refactors the `AbstractClient` class to use this factory for creating requests and adapters. This change simplifies client instantiation and improves flexibility by decoupling the creation logic from the client itself.