### PR TITLE
feat: add streaming functionality for responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@
 - Renamed `EasyClientContract` to `HTTPClientContract`. ([#4](https://github.com/easy-http/contracts/pull/4))
 - Renamed `ImpossibleToParseJsonException` to `HTTPJsonParseException`. ([#5](https://github.com/easy-http/contracts/pull/5))
 - Introduced `HTTPClientFactory` and refactored `AbstractClient` to create requests and adapters through factory methods. ([#6](https://github.com/easy-http/contracts/pull/6))
+- Added streaming support to `AbstractClient`/`HTTPClientContract` via `stream()` and extended `HTTPClientAdapter` with `stream(HTTPClientRequest $request): HTTPStreamResponse`. ([#8](https://github.com/easy-http/contracts/pull/8))
 
 ### Added
 - URL-encoded request data support to `HTTPClientRequest`/`ClientRequest` via `setUrlEncodedData()`, `getUrlEncodedData()`, and `hasUrlEncodedData()`. ([#7](https://github.com/easy-http/contracts/pull/7))
+- Introduced `HTTPStreamResponse` contract. ([#8](https://github.com/easy-http/contracts/pull/8))
 
 ## [v2.0.0 (2025-06-15)](https://github.com/easy-http/contracts/tree/v2.0.0)
 

--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -6,6 +6,7 @@ use EasyHTTP\Contracts\Contracts\HTTPClientContract;
 use EasyHTTP\Contracts\Contracts\HTTPClientAdapter;
 use EasyHTTP\Contracts\Contracts\HTTPClientRequest;
 use EasyHTTP\Contracts\Contracts\HTTPClientResponse;
+use EasyHTTP\Contracts\Contracts\HTTPStreamResponse;
 
 abstract class AbstractClient implements HTTPClientContract
 {
@@ -48,6 +49,11 @@ abstract class AbstractClient implements HTTPClientContract
     public function execute(): HTTPClientResponse
     {
         return $this->getAdapter()->request($this->request);
+    }
+
+    public function stream(): HTTPStreamResponse
+    {
+        return $this->getAdapter()->stream($this->request);
     }
 
     protected function getAdapter(): HTTPClientAdapter

--- a/src/Contracts/HTTPClientAdapter.php
+++ b/src/Contracts/HTTPClientAdapter.php
@@ -12,4 +12,11 @@ interface HTTPClientAdapter
      * @throws HTTPClientException
      */
     public function request(HTTPClientRequest $request): HTTPClientResponse;
+
+    /**
+     * @param HTTPClientRequest $request
+     * @return HTTPStreamResponse
+     * @throws HTTPClientException
+     */
+    public function stream(HTTPClientRequest $request): HTTPStreamResponse;
 }

--- a/src/Contracts/HTTPClientContract.php
+++ b/src/Contracts/HTTPClientContract.php
@@ -9,4 +9,5 @@ interface HTTPClientContract
     public function prepareRequest(string $method, string $uri): HTTPClientRequest;
     public function withHandler(callable $handler): self;
     public function execute(): HTTPClientResponse;
+    public function stream(): HTTPStreamResponse;
 }

--- a/src/Contracts/HTTPStreamResponse.php
+++ b/src/Contracts/HTTPStreamResponse.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace EasyHTTP\Contracts\Contracts;
+
+use Generator;
+
+interface HTTPStreamResponse
+{
+    public function getStatusCode(): int;
+    public function getHeaders(): array;
+    public function getBody(): Generator;
+}

--- a/tests/Unit/AbstractClientTest.php
+++ b/tests/Unit/AbstractClientTest.php
@@ -3,6 +3,7 @@
 namespace EasyHTTP\Contracts\Tests\Unit;
 
 use EasyHTTP\Contracts\Contracts\HTTPClientResponse;
+use EasyHTTP\Contracts\Contracts\HTTPStreamResponse;
 use EasyHTTP\Contracts\Exceptions\HTTPClientException;
 use EasyHTTP\Contracts\Exceptions\HTTPConnectionException;
 use EasyHTTP\Contracts\Exceptions\HTTPJsonParseException;
@@ -71,6 +72,50 @@ class AbstractClientTest extends TestCase
             ['Server' => 'Apache/2.4.38 (Debian)', 'X-Info' => 'GET ' . $this->uri],
             $response->getHeaders()
         );
+    }
+
+    /**
+     * @test
+     */
+    public function itStreamsAPreparedRequest(): HTTPStreamResponse
+    {
+        $client = new SomeClient();
+        $client->prepareRequest('GET', $this->uri);
+
+        $response = $client->stream();
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(
+            ['Server' => 'Apache/2.4.38 (Debian)', 'X-Info' => 'GET ' . $this->uri],
+            $response->getHeaders()
+        );
+        $this->assertSame(['{"key":"value"}'], iterator_to_array($response->getBody(), false));
+
+        return $response;
+    }
+
+    /**
+     * @test
+     */
+    public function itStreamsWithCustomHandler()
+    {
+        $client = new SomeClient();
+        $client->withHandler(
+            function () {
+                return [
+                    'status' => 206,
+                    'headers' => ['Server' => 'Apache/2.4.38 (Ubuntu)'],
+                    'body' => 'chunk one chunk two',
+                ];
+            }
+        );
+        $client->prepareRequest('GET', $this->uri);
+
+        $response = $client->stream();
+
+        $this->assertSame(206, $response->getStatusCode());
+        $this->assertSame(['Server' => 'Apache/2.4.38 (Ubuntu)'], $response->getHeaders());
+        $this->assertSame(['chunk', 'one', 'chunk', 'two'], iterator_to_array($response->getBody(), false));
     }
 
     /**

--- a/tests/Unit/Example/ClientAdapter.php
+++ b/tests/Unit/Example/ClientAdapter.php
@@ -5,6 +5,7 @@ namespace EasyHTTP\Contracts\Tests\Unit\Example;
 use EasyHTTP\Contracts\Contracts\HTTPClientAdapter;
 use EasyHTTP\Contracts\Contracts\HTTPClientRequest;
 use EasyHTTP\Contracts\Contracts\HTTPClientResponse;
+use EasyHTTP\Contracts\Contracts\HTTPStreamResponse;
 
 class ClientAdapter implements HTTPClientAdapter
 {
@@ -19,6 +20,12 @@ class ClientAdapter implements HTTPClientAdapter
     {
         $response = $this->call($request->getMethod(), $request->getUri());
         return new ClientResponse($response);
+    }
+
+    public function stream(HTTPClientRequest $request): HTTPStreamResponse
+    {
+        $response = $this->call($request->getMethod(), $request->getUri());
+        return new StreamResponse($response);
     }
 
     private function call(string $method, string $uri): array

--- a/tests/Unit/Example/StreamResponse.php
+++ b/tests/Unit/Example/StreamResponse.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace EasyHTTP\Contracts\Tests\Unit\Example;
+
+use EasyHTTP\Contracts\Contracts\HTTPStreamResponse;
+use Generator;
+
+class StreamResponse implements HTTPStreamResponse
+{
+    protected array $headers;
+    protected int $status;
+    protected Generator $body;
+
+    public function __construct(array $response)
+    {
+        $this->headers = $response['headers'];
+        $this->status = $response['status'];
+
+        $body = $response['body'];
+        $generator = function () use ($body): Generator {
+            // breakdown the body by spaces into chunks
+            $chunks = explode(' ', $body);
+            foreach ($chunks as $chunk) {
+                yield $chunk;
+            }
+        };
+
+        $this->body = $generator();
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->status;
+    }
+
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    public function getBody(): Generator
+    {
+        return $this->body;
+    }
+}


### PR DESCRIPTION
This pull request introduces data streaming support for responses to the HTTP client contracts. The main changes include the addition of a new `HTTPStreamResponse` contract, updates to the `HTTPClientContract` and `HTTPClientAdapter` interfaces, and corresponding implementations and tests.