### PR TITLE
feat: introduce BodyPayloadContract and dedicated body payload implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,19 @@
 - Renamed `ImpossibleToParseJsonException` to `HTTPJsonParseException`. ([#5](https://github.com/easy-http/contracts/pull/5))
 - Introduced `HTTPClientFactory` and refactored `AbstractClient` to create requests and adapters through factory methods. ([#6](https://github.com/easy-http/contracts/pull/6))
 - Added streaming support to `AbstractClient`/`HTTPClientContract` via `stream()` and extended `HTTPClientAdapter` with `stream(HTTPClientRequest $request): HTTPStreamResponse`. ([#8](https://github.com/easy-http/contracts/pull/8))
+- Refactored `HTTPClientRequest`/`ClientRequest` to use `BodyPayloadContract` as the canonical request body abstraction. ([#9](https://github.com/easy-http/contracts/pull/9))
+- Created dedicated body payload interfaces (e.g. `StringBodyPayloadContract`, `JsonBodyPayloadContract`, `IterableBodyPayloadContract`, `ResourceBodyPayloadContract`, and `UrlEncodedBodyPayloadContract`) that replace previous tailored methods in requests. ([#9](https://github.com/easy-http/contracts/pull/9))
 
 ### Added
 - URL-encoded request data support to `HTTPClientRequest`/`ClientRequest` via `setUrlEncodedData()`, `getUrlEncodedData()`, and `hasUrlEncodedData()`. ([#7](https://github.com/easy-http/contracts/pull/7))
 - Introduced `HTTPStreamResponse` contract. ([#8](https://github.com/easy-http/contracts/pull/8))
+- Added `setBodyPayload()` and `getBodyPayload()` to `HTTPClientRequest`/`ClientRequest`. ([#9](https://github.com/easy-http/contracts/pull/9))
+- Added dedicated body payload contracts and implementations for string, JSON, iterable, resource, and URL-encoded payloads. ([#9](https://github.com/easy-http/contracts/pull/9))
+
+### Removed
+- Removed `getJson()`, `setJson()`, and `hasJson()` from `HTTPClientRequest` and `ClientRequest`. ([#9](https://github.com/easy-http/contracts/pull/9))
+- Removed `getBody()`, `setBody()`, and `hasBody()` from `HTTPClientRequest` and `ClientRequest`. ([#9](https://github.com/easy-http/contracts/pull/9))
+- Removed `getUrlEncodedData()`, `setUrlEncodedData()`, and `hasUrlEncodedData()` from `HTTPClientRequest` and `ClientRequest` in favor of URL-encoded body payloads. ([#9](https://github.com/easy-http/contracts/pull/9))
 
 ## [v2.0.0 (2025-06-15)](https://github.com/easy-http/contracts/tree/v2.0.0)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 **A Solid set of Adapter-Driven HTTP contracts for PHP**
 
-We provide differet adapters for common HTTP Clients like Guzzle, Symfony and others.
+We provide different adapters for common HTTP Clients like Guzzle, Symfony and others.
 
 📚 Check out the [Documentation](https://easy-http.com/docs) to learn how to use any adapter that implements these contracts.
 

--- a/src/Common/ClientRequest.php
+++ b/src/Common/ClientRequest.php
@@ -2,6 +2,7 @@
 
 namespace EasyHTTP\Contracts\Common;
 
+use EasyHTTP\Contracts\Contracts\BodyPayload\BodyPayloadContract;
 use EasyHTTP\Contracts\Contracts\HTTPClientRequest;
 use EasyHTTP\Contracts\Contracts\Request\HTTPSecurityContext;
 
@@ -10,10 +11,8 @@ class ClientRequest implements HTTPClientRequest
     protected string $method;
     protected string $uri;
     protected array $headers = [];
-    protected string $body = '';
-    protected array $json = [];
+    protected ?BodyPayloadContract $bodyPayload = null;
     protected array $query = [];
-    protected array $urlEncodedData = [];
     protected ?HTTPSecurityContext $securityContext = null;
     protected int $timeout = 10;
     protected array $basicAuth = [];
@@ -45,34 +44,14 @@ class ClientRequest implements HTTPClientRequest
         return $this->headers;
     }
 
-    public function getBody(): string
+    public function getBodyPayload(): ?BodyPayloadContract
     {
-        if (!$this->hasJson()) {
-            return $this->body;
-        }
-        
-        $body = json_encode($this->json);
-
-        if (!$body) {
-            return '';
-        }
-
-        return $body;
-    }
-
-    public function getJson(): array
-    {
-        return $this->json;
+        return $this->bodyPayload;
     }
 
     public function getQuery(): array
     {
         return $this->query;
-    }
-
-    public function getUrlEncodedData(): array
-    {
-        return $this->urlEncodedData;
     }
 
     public function getTimeout(): int
@@ -90,30 +69,9 @@ class ClientRequest implements HTTPClientRequest
         return $this->basicAuth;
     }
 
-    public function hasBody(): bool
-    {
-        if (!$this->hasJson()) {
-            return !empty($this->body);
-        }
-
-        $body = json_encode($this->json);
-
-        return (bool) !empty($body);
-    }
-
-    public function hasJson(): bool
-    {
-        return !empty($this->json);
-    }
-
     public function hasQuery(): bool
     {
         return !empty($this->query);
-    }
-
-    public function hasUrlEncodedData(): bool
-    {
-        return !empty($this->urlEncodedData);
     }
 
     public function hasHeaders(): bool
@@ -161,17 +119,9 @@ class ClientRequest implements HTTPClientRequest
         return $this;
     }
 
-    public function setBody(string $body): self
+    public function setBodyPayload(BodyPayloadContract $bodyPayload): self
     {
-        $this->json = [];
-        $this->body = $body;
-
-        return $this;
-    }
-
-    public function setJson(array $json): self
-    {
-        $this->json = $json;
+        $this->bodyPayload = $bodyPayload;
 
         return $this;
     }
@@ -179,13 +129,6 @@ class ClientRequest implements HTTPClientRequest
     public function setQuery(array $query): self
     {
         $this->query = $query;
-
-        return $this;
-    }
-
-    public function setUrlEncodedData(array $urlEncodedData): self
-    {
-        $this->urlEncodedData = $urlEncodedData;
 
         return $this;
     }

--- a/src/Common/ClientRequest.php
+++ b/src/Common/ClientRequest.php
@@ -89,6 +89,11 @@ class ClientRequest implements HTTPClientRequest
         return !empty($this->basicAuth);
     }
 
+    public function hasBodyPayload(): bool
+    {
+        return $this->getBodyPayload() !== null;
+    }
+
     public function setMethod(string $method): self
     {
         $this->method = $method;

--- a/src/Common/Request/IterableBodyPayload.php
+++ b/src/Common/Request/IterableBodyPayload.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace EasyHTTP\Contracts\Common\Request;
+
+use EasyHTTP\Contracts\Contracts\BodyPayload\IterableBodyPayloadContract;
+
+class IterableBodyPayload implements IterableBodyPayloadContract
+{
+    protected iterable $payload;
+
+    public function __construct(iterable $payload)
+    {
+        $this->payload = $payload;
+    }
+
+    public function getContents(): iterable
+    {
+        return $this->payload;
+    }
+}

--- a/src/Common/Request/JsonBodyPayload.php
+++ b/src/Common/Request/JsonBodyPayload.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace EasyHTTP\Contracts\Common\Request;
+
+use EasyHTTP\Contracts\Contracts\BodyPayload\JsonBodyPayloadContract;
+
+class JsonBodyPayload implements JsonBodyPayloadContract
+{
+    protected array $payload;
+
+    public function __construct(array $payload)
+    {
+        $this->payload = $payload;
+    }
+
+    public function getContents(): array
+    {
+        return $this->payload;
+    }
+}

--- a/src/Common/Request/ResourceBodyPayload.php
+++ b/src/Common/Request/ResourceBodyPayload.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace EasyHTTP\Contracts\Common\Request;
+
+use EasyHTTP\Contracts\Contracts\BodyPayload\ResourceBodyPayloadContract;
+use InvalidArgumentException;
+
+class ResourceBodyPayload implements ResourceBodyPayloadContract
+{
+    protected $payload;
+
+    /**
+     * @param resource $payload
+     */
+    public function __construct($payload)
+    {
+        if (!is_resource($payload)) {
+            throw new InvalidArgumentException('ResourceBodyPayload expects a valid resource.');
+        }
+
+        $this->payload = $payload;
+    }
+
+    /**
+     * @return resource
+     */
+    public function getContents()
+    {
+        return $this->payload;
+    }
+}

--- a/src/Common/Request/StringBodyPayload.php
+++ b/src/Common/Request/StringBodyPayload.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace EasyHTTP\Contracts\Common\Request;
+
+use EasyHTTP\Contracts\Contracts\BodyPayload\StringBodyPayloadContract;
+
+class StringBodyPayload implements StringBodyPayloadContract
+{
+    protected string $payload;
+
+    public function __construct(string $payload)
+    {
+        $this->payload = $payload;
+    }
+
+    public function getContents(): string
+    {
+        return $this->payload;
+    }
+}

--- a/src/Common/Request/UrlEncodedBodyPayload.php
+++ b/src/Common/Request/UrlEncodedBodyPayload.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace EasyHTTP\Contracts\Common\Request;
+
+use EasyHTTP\Contracts\Contracts\BodyPayload\UrlEncodedBodyPayloadContract;
+
+class UrlEncodedBodyPayload implements UrlEncodedBodyPayloadContract
+{
+    protected array $payload;
+
+    public function __construct(array $payload)
+    {
+        $this->payload = $payload;
+    }
+
+    public function getContents(): array
+    {
+        return $this->payload;
+    }
+}

--- a/src/Contracts/BodyPayload/BodyPayloadContract.php
+++ b/src/Contracts/BodyPayload/BodyPayloadContract.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace EasyHTTP\Contracts\Contracts\BodyPayload;
+
+interface BodyPayloadContract
+{
+    public function getContents();
+}

--- a/src/Contracts/BodyPayload/IterableBodyPayloadContract.php
+++ b/src/Contracts/BodyPayload/IterableBodyPayloadContract.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace EasyHTTP\Contracts\Contracts\BodyPayload;
+
+interface IterableBodyPayloadContract extends BodyPayloadContract
+{
+    public function getContents(): iterable;
+}

--- a/src/Contracts/BodyPayload/JsonBodyPayloadContract.php
+++ b/src/Contracts/BodyPayload/JsonBodyPayloadContract.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace EasyHTTP\Contracts\Contracts\BodyPayload;
+
+interface JsonBodyPayloadContract extends BodyPayloadContract
+{
+    /**
+     * Returns an array of key -> value pairs to be sent as JSON
+     * Ex: ['foo' => 'bar', 'flag' => true]
+     *
+     * @return array
+     */
+    public function getContents(): array;
+}

--- a/src/Contracts/BodyPayload/ResourceBodyPayloadContract.php
+++ b/src/Contracts/BodyPayload/ResourceBodyPayloadContract.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace EasyHTTP\Contracts\Contracts\BodyPayload;
+
+interface ResourceBodyPayloadContract extends BodyPayloadContract
+{
+    /**
+     * @return resource
+     */
+    public function getContents();
+}

--- a/src/Contracts/BodyPayload/StringBodyPayloadContract.php
+++ b/src/Contracts/BodyPayload/StringBodyPayloadContract.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace EasyHTTP\Contracts\Contracts\BodyPayload;
+
+interface StringBodyPayloadContract extends BodyPayloadContract
+{
+    public function getContents(): string;
+}

--- a/src/Contracts/BodyPayload/UrlEncodedBodyPayloadContract.php
+++ b/src/Contracts/BodyPayload/UrlEncodedBodyPayloadContract.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace EasyHTTP\Contracts\Contracts\BodyPayload;
+
+interface UrlEncodedBodyPayloadContract extends BodyPayloadContract
+{
+    /**
+     * Returns an array of key -> value pairs to be sent as URL-encoded form data
+     * Ex: ['foo' => 'bar', 'flag' => true]
+     *
+     * @return array
+     */
+    public function getContents(): array;
+}

--- a/src/Contracts/HTTPClientRequest.php
+++ b/src/Contracts/HTTPClientRequest.php
@@ -2,6 +2,7 @@
 
 namespace EasyHTTP\Contracts\Contracts;
 
+use EasyHTTP\Contracts\Contracts\BodyPayload\BodyPayloadContract;
 use EasyHTTP\Contracts\Contracts\Request\HTTPSecurityContext;
 
 interface HTTPClientRequest
@@ -18,15 +19,19 @@ interface HTTPClientRequest
      */
     public function getHeaders(): array;
 
-    public function getBody(): string;
-
     /**
-     * Returns the value encoded in JSON as an array of key -> value pairs
-     * Ex: ['foo' => 'bar', 'flag' => 'enabled']
+     * Returns the body payload.
      *
-     * @return array
+     * This interface defines a common way to get the body payload from the request.
+     * Some examples of body payloads are:
+     *
+     * - strings
+     * - resources
+     * - iterables
+     *
+     * @return BodyPayloadContract|null
      */
-    public function getJson(): array;
+    public function getBodyPayload(): ?BodyPayloadContract;
 
     /**
      * Returns an array of key -> value pairs of query parameters
@@ -35,14 +40,6 @@ interface HTTPClientRequest
      * @return array
      */
     public function getQuery(): array;
-
-    /**
-     * Returns an array of key -> value pairs to be sent as URL-encoded form data
-     * Ex: ['foo' => 'bar', 'flag' => 'enabled']
-     *
-     * @return array
-     */
-    public function getUrlEncodedData(): array;
 
     public function getTimeout(): int;
     public function getSecurityContext(): ?HTTPSecurityContext;
@@ -57,10 +54,7 @@ interface HTTPClientRequest
     public function getBasicAuth(): array;
 
     public function hasHeaders(): bool;
-    public function hasBody(): bool;
-    public function hasJson(): bool;
     public function hasQuery(): bool;
-    public function hasUrlEncodedData(): bool;
     public function hasSecurityContext(): bool;
     public function hasBasicAuth(): bool;
 
@@ -68,10 +62,8 @@ interface HTTPClientRequest
     public function setUri(string $uri): self;
     public function setHeader(string $key, string $value): self;
     public function setHeaders(array $headers): self;
-    public function setBody(string $body): self;
-    public function setJson(array $json): self;
+    public function setBodyPayload(BodyPayloadContract $bodyPayload): self;
     public function setQuery(array $query): self;
-    public function setUrlEncodedData(array $urlEncodedData): self;
 
     public function setTimeout(int $timeout): self;
     public function setSecurityContext(HTTPSecurityContext $securityContext): self;

--- a/src/Contracts/HTTPClientRequest.php
+++ b/src/Contracts/HTTPClientRequest.php
@@ -57,6 +57,7 @@ interface HTTPClientRequest
     public function hasQuery(): bool;
     public function hasSecurityContext(): bool;
     public function hasBasicAuth(): bool;
+    public function hasBodyPayload(): bool;
 
     public function setMethod(string $method): self;
     public function setUri(string $uri): self;

--- a/tests/Unit/Common/ClientRequestTest.php
+++ b/tests/Unit/Common/ClientRequestTest.php
@@ -2,6 +2,11 @@
 
 namespace EasyHTTP\Contracts\Tests\Unit\Common;
 
+use EasyHTTP\Contracts\Common\Request\IterableBodyPayload;
+use EasyHTTP\Contracts\Common\Request\JsonBodyPayload;
+use EasyHTTP\Contracts\Common\Request\ResourceBodyPayload;
+use EasyHTTP\Contracts\Common\Request\StringBodyPayload;
+use EasyHTTP\Contracts\Common\Request\UrlEncodedBodyPayload;
 use EasyHTTP\Contracts\Common\SecurityContext;
 use EasyHTTP\Contracts\Tests\TestCase;
 use EasyHTTP\Contracts\Tests\Unit\Example\ClientRequest;
@@ -21,10 +26,8 @@ class ClientRequestTest extends TestCase
         $this->assertSame($method, $request->getMethod());
         $this->assertSame($url, $request->getUri());
         $this->assertFalse($request->hasHeaders());
-        $this->assertEmpty($request->getBody());
-        $this->assertFalse($request->hasJson());
+        $this->assertNull($request->getBodyPayload());
         $this->assertFalse($request->hasQuery());
-        $this->assertFalse($request->hasUrlEncodedData());
         $this->assertFalse($request->hasSecurityContext());
         $this->assertFalse($request->isSSL());
         $this->assertFalse($request->hasBasicAuth());
@@ -41,9 +44,9 @@ class ClientRequestTest extends TestCase
         $url = $this->faker->url;
         $request->setMethod($method);
         $request->setUri($url);
-        $request->setJson(['foo' => 'bar']);
+        $payload = new JsonBodyPayload(['foo' => 'bar']);
+        $request->setBodyPayload($payload);
         $request->setQuery(['bar' => 'baz']);
-        $request->setUrlEncodedData(['alpha' => 'beta']);
         $request->setTimeout(20);
         $request->setHeaders(['a' => 'b']);
         $request->setHeader('auth', 'xdsG56');
@@ -54,12 +57,9 @@ class ClientRequestTest extends TestCase
 
         $this->assertSame($method, $request->getMethod());
         $this->assertSame($url, $request->getUri());
-        $this->assertSame(['foo' => 'bar'], $request->getJson());
-        $this->assertTrue($request->hasJson());
+        $this->assertSame($payload, $request->getBodyPayload());
         $this->assertSame(['bar' => 'baz'], $request->getQuery());
         $this->assertTrue($request->hasQuery());
-        $this->assertSame(['alpha' => 'beta'], $request->getUrlEncodedData());
-        $this->assertTrue($request->hasUrlEncodedData());
         $this->assertSame(20, $request->getTimeout());
         $this->assertSame('xdsG56', $request->getHeader('auth'));
         $this->assertSame(['a' => 'b', 'auth' => 'xdsG56'], $request->getHeaders());
@@ -73,81 +73,94 @@ class ClientRequestTest extends TestCase
     /**
      * @test
      */
-    public function itCanSetTheBodyAsJson()
+    public function itCanAssignAStringBodyPayload()
     {
         $request = new ClientRequest('POST', $this->faker->url);
+        $payload = new StringBodyPayload('Some payload');
 
-        $request->setJson(['foo' => 'bar']);
+        $request->setBodyPayload($payload);
 
-        $this->assertSame(['foo' => 'bar'], $request->getJson());
-        $this->assertSame('{"foo":"bar"}', $request->getBody());
+        $this->assertSame($payload, $request->getBodyPayload());
+        $this->assertSame('Some payload', $request->getBodyPayload()->getContents());
     }
 
     /**
      * @test
      */
-    public function itCannotParseWrontJsonValues()
+    public function itCanAssignAJsonBodyPayload()
     {
         $request = new ClientRequest('POST', $this->faker->url);
+        $payload = new JsonBodyPayload(['foo' => 'bar']);
 
-        $request->setJson(["\xc3" => 'bar']);
+        $request->setBodyPayload($payload);
 
-        $this->assertSame('', $request->getBody());
+        $this->assertSame($payload, $request->getBodyPayload());
+        $this->assertSame(['foo' => 'bar'], $request->getBodyPayload()->getContents());
     }
 
     /**
      * @test
      */
-    public function itCanChangeTheBodyPreviouslyAsJson()
+    public function itCanAssignAUrlEncodedBodyPayload()
     {
         $request = new ClientRequest('POST', $this->faker->url);
+        $payload = new UrlEncodedBodyPayload(['foo' => 'bar', 'flag' => 'enabled']);
 
-        $request->setJson(['foo' => 'bar']);
-        $request->setBody('Not Found');
+        $request->setBodyPayload($payload);
 
-        $this->assertSame([], $request->getJson());
-        $this->assertSame('Not Found', $request->getBody());
+        $this->assertSame($payload, $request->getBodyPayload());
+        $this->assertSame(['foo' => 'bar', 'flag' => 'enabled'], $request->getBodyPayload()->getContents());
     }
 
     /**
      * @test
      */
-    public function itCanChangeTheBodyPreviouslyAsPlainText()
+    public function itCanAssignAnIterableBodyPayload()
     {
         $request = new ClientRequest('POST', $this->faker->url);
+        $payload = new IterableBodyPayload(['chunk-one', 'chunk-two']);
 
-        $request->setBody('Not Found');
-        $request->setJson(['foo' => 'bar']);
+        $request->setBodyPayload($payload);
 
-        $this->assertSame(['foo' => 'bar'], $request->getJson());
-        $this->assertSame('{"foo":"bar"}', $request->getBody());
+        $this->assertSame($payload, $request->getBodyPayload());
+        $this->assertSame(
+            ['chunk-one', 'chunk-two'],
+            iterator_to_array($request->getBodyPayload()->getContents(), false)
+        );
     }
 
     /**
      * @test
      */
-    public function itHasBodyForJsonAssignment()
+    public function itCanAssignAResourceBodyPayload()
     {
         $request = new ClientRequest('POST', $this->faker->url);
+        $resource = fopen('php://memory', 'r+');
+        $this->assertIsResource($resource);
+        fwrite($resource, 'sample');
+        rewind($resource);
+        $payload = new ResourceBodyPayload($resource);
 
-        $this->assertFalse($request->hasBody());
+        $request->setBodyPayload($payload);
 
-        $request->setJson(['foo' => 'bar']);
+        $this->assertSame($payload, $request->getBodyPayload());
+        $this->assertIsResource($request->getBodyPayload()->getContents());
 
-        $this->assertTrue($request->hasBody());
+        fclose($resource);
     }
 
     /**
      * @test
      */
-    public function itHasBodyWhenItIsAssigned()
+    public function itReplacesBodyPayloadWhenSettingAnotherOne()
     {
         $request = new ClientRequest('POST', $this->faker->url);
+        $request->setBodyPayload(new StringBodyPayload('first'));
 
-        $this->assertFalse($request->hasBody());
+        $payload = new JsonBodyPayload(['next' => 'value']);
+        $request->setBodyPayload($payload);
 
-        $request->setBody('Not Found');
-
-        $this->assertTrue($request->hasBody());
+        $this->assertSame($payload, $request->getBodyPayload());
+        $this->assertSame(['next' => 'value'], $request->getBodyPayload()->getContents());
     }
 }

--- a/tests/Unit/Common/ClientRequestTest.php
+++ b/tests/Unit/Common/ClientRequestTest.php
@@ -2,11 +2,7 @@
 
 namespace EasyHTTP\Contracts\Tests\Unit\Common;
 
-use EasyHTTP\Contracts\Common\Request\IterableBodyPayload;
 use EasyHTTP\Contracts\Common\Request\JsonBodyPayload;
-use EasyHTTP\Contracts\Common\Request\ResourceBodyPayload;
-use EasyHTTP\Contracts\Common\Request\StringBodyPayload;
-use EasyHTTP\Contracts\Common\Request\UrlEncodedBodyPayload;
 use EasyHTTP\Contracts\Common\SecurityContext;
 use EasyHTTP\Contracts\Tests\TestCase;
 use EasyHTTP\Contracts\Tests\Unit\Example\ClientRequest;
@@ -23,10 +19,11 @@ class ClientRequestTest extends TestCase
 
         $request = new ClientRequest($method, $url);
 
+        // everything else has not been set yet
         $this->assertSame($method, $request->getMethod());
         $this->assertSame($url, $request->getUri());
         $this->assertFalse($request->hasHeaders());
-        $this->assertNull($request->getBodyPayload());
+        $this->assertFalse($request->hasBodyPayload());
         $this->assertFalse($request->hasQuery());
         $this->assertFalse($request->hasSecurityContext());
         $this->assertFalse($request->isSSL());
@@ -42,6 +39,7 @@ class ClientRequestTest extends TestCase
 
         $method = 'GET';
         $url = $this->faker->url;
+
         $request->setMethod($method);
         $request->setUri($url);
         $payload = new JsonBodyPayload(['foo' => 'bar']);
@@ -68,99 +66,5 @@ class ClientRequestTest extends TestCase
         $this->assertTrue($request->hasBasicAuth());
         $this->assertTrue($request->hasSecurityContext());
         $this->assertTrue($request->isSSL());
-    }
-
-    /**
-     * @test
-     */
-    public function itCanAssignAStringBodyPayload()
-    {
-        $request = new ClientRequest('POST', $this->faker->url);
-        $payload = new StringBodyPayload('Some payload');
-
-        $request->setBodyPayload($payload);
-
-        $this->assertSame($payload, $request->getBodyPayload());
-        $this->assertSame('Some payload', $request->getBodyPayload()->getContents());
-    }
-
-    /**
-     * @test
-     */
-    public function itCanAssignAJsonBodyPayload()
-    {
-        $request = new ClientRequest('POST', $this->faker->url);
-        $payload = new JsonBodyPayload(['foo' => 'bar']);
-
-        $request->setBodyPayload($payload);
-
-        $this->assertSame($payload, $request->getBodyPayload());
-        $this->assertSame(['foo' => 'bar'], $request->getBodyPayload()->getContents());
-    }
-
-    /**
-     * @test
-     */
-    public function itCanAssignAUrlEncodedBodyPayload()
-    {
-        $request = new ClientRequest('POST', $this->faker->url);
-        $payload = new UrlEncodedBodyPayload(['foo' => 'bar', 'flag' => 'enabled']);
-
-        $request->setBodyPayload($payload);
-
-        $this->assertSame($payload, $request->getBodyPayload());
-        $this->assertSame(['foo' => 'bar', 'flag' => 'enabled'], $request->getBodyPayload()->getContents());
-    }
-
-    /**
-     * @test
-     */
-    public function itCanAssignAnIterableBodyPayload()
-    {
-        $request = new ClientRequest('POST', $this->faker->url);
-        $payload = new IterableBodyPayload(['chunk-one', 'chunk-two']);
-
-        $request->setBodyPayload($payload);
-
-        $this->assertSame($payload, $request->getBodyPayload());
-        $this->assertSame(
-            ['chunk-one', 'chunk-two'],
-            iterator_to_array($request->getBodyPayload()->getContents(), false)
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function itCanAssignAResourceBodyPayload()
-    {
-        $request = new ClientRequest('POST', $this->faker->url);
-        $resource = fopen('php://memory', 'r+');
-        $this->assertIsResource($resource);
-        fwrite($resource, 'sample');
-        rewind($resource);
-        $payload = new ResourceBodyPayload($resource);
-
-        $request->setBodyPayload($payload);
-
-        $this->assertSame($payload, $request->getBodyPayload());
-        $this->assertIsResource($request->getBodyPayload()->getContents());
-
-        fclose($resource);
-    }
-
-    /**
-     * @test
-     */
-    public function itReplacesBodyPayloadWhenSettingAnotherOne()
-    {
-        $request = new ClientRequest('POST', $this->faker->url);
-        $request->setBodyPayload(new StringBodyPayload('first'));
-
-        $payload = new JsonBodyPayload(['next' => 'value']);
-        $request->setBodyPayload($payload);
-
-        $this->assertSame($payload, $request->getBodyPayload());
-        $this->assertSame(['next' => 'value'], $request->getBodyPayload()->getContents());
     }
 }

--- a/tests/Unit/Common/Request/BodyPayloadTest.php
+++ b/tests/Unit/Common/Request/BodyPayloadTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace EasyHTTP\Contracts\Tests\Unit\Common\Request;
+
+use EasyHTTP\Contracts\Common\Request\IterableBodyPayload;
+use EasyHTTP\Contracts\Common\Request\JsonBodyPayload;
+use EasyHTTP\Contracts\Common\Request\ResourceBodyPayload;
+use EasyHTTP\Contracts\Common\Request\StringBodyPayload;
+use EasyHTTP\Contracts\Common\Request\UrlEncodedBodyPayload;
+use EasyHTTP\Contracts\Tests\TestCase;
+use EasyHTTP\Contracts\Tests\Unit\Example\ClientRequest;
+use ArrayIterator;
+use Generator;
+
+class BodyPayloadTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itCanAssignAStringBodyPayload()
+    {
+        $request = new ClientRequest('POST', $this->faker->url);
+        $payload = new StringBodyPayload('Some payload');
+
+        $request->setBodyPayload($payload);
+
+        $this->assertSame($payload, $request->getBodyPayload());
+        $this->assertSame('Some payload', $request->getBodyPayload()->getContents());
+    }
+
+    /**
+     * @test
+     */
+    public function itCanAssignAJsonBodyPayload()
+    {
+        $request = new ClientRequest('POST', $this->faker->url);
+        $payload = new JsonBodyPayload(['foo' => 'bar']);
+
+        $request->setBodyPayload($payload);
+
+        $this->assertSame($payload, $request->getBodyPayload());
+        $this->assertSame(['foo' => 'bar'], $request->getBodyPayload()->getContents());
+    }
+
+    /**
+     * @test
+     */
+    public function itCanAssignAUrlEncodedBodyPayload()
+    {
+        $request = new ClientRequest('POST', $this->faker->url);
+        $payload = new UrlEncodedBodyPayload(['foo' => 'bar', 'flag' => 'enabled']);
+
+        $request->setBodyPayload($payload);
+
+        $this->assertSame($payload, $request->getBodyPayload());
+        $this->assertSame(['foo' => 'bar', 'flag' => 'enabled'], $request->getBodyPayload()->getContents());
+    }
+
+    /**
+     * @test
+     */
+    public function itCanAssignAnArrayBodyPayload()
+    {
+        $request = new ClientRequest('POST', $this->faker->url);
+        $payload = new IterableBodyPayload(['chunk-one', 'chunk-two']);
+
+        $request->setBodyPayload($payload);
+
+        $this->assertSame($payload, $request->getBodyPayload());
+        $this->assertSame(
+            ['chunk-one', 'chunk-two'],
+            $request->getBodyPayload()->getContents()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itCanAssignATraversableBodyPayload()
+    {
+        $request = new ClientRequest('POST', $this->faker->url);
+        $payload = new IterableBodyPayload(new ArrayIterator(['chunk-one', 'chunk-two']));
+
+        $request->setBodyPayload($payload);
+
+        $this->assertSame($payload, $request->getBodyPayload());
+        $this->assertSame(
+            ['chunk-one', 'chunk-two'],
+            iterator_to_array($request->getBodyPayload()->getContents(), false)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itCanAssignAGeneratorBodyPayload()
+    {
+        $request = new ClientRequest('POST', $this->faker->url);
+
+        $generator = function (string $data): Generator {
+            // breakdown the body by spaces into chunks
+            $chunks = explode(' ', $data);
+            foreach ($chunks as $chunk) {
+                yield $chunk;
+            }
+        };
+
+        $generatorExample = function () use ($generator) {
+            return $generator('key value');
+        };
+
+        $payload = new IterableBodyPayload($generatorExample());
+
+        $request->setBodyPayload($payload);
+
+        $this->assertSame($payload, $request->getBodyPayload());
+        $this->assertSame(
+            ['key', 'value'],
+            iterator_to_array($request->getBodyPayload()->getContents(), false)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itCanAssignAResourceBodyPayload()
+    {
+        $request = new ClientRequest('POST', $this->faker->url);
+        $resource = fopen('php://memory', 'r+');
+        $this->assertIsResource($resource);
+        fwrite($resource, 'sample');
+        rewind($resource);
+        $payload = new ResourceBodyPayload($resource);
+
+        $request->setBodyPayload($payload);
+
+        $this->assertSame($payload, $request->getBodyPayload());
+        $this->assertIsResource($request->getBodyPayload()->getContents());
+
+        fclose($resource);
+    }
+
+    /**
+     * @test
+     */
+    public function itReplacesBodyPayloadWhenSettingAnotherOne()
+    {
+        $request = new ClientRequest('POST', $this->faker->url);
+        $request->setBodyPayload(new StringBodyPayload('first'));
+
+        $payload = new JsonBodyPayload(['next' => 'value']);
+        $request->setBodyPayload($payload);
+
+        $this->assertSame($payload, $request->getBodyPayload());
+        $this->assertSame(['next' => 'value'], $request->getBodyPayload()->getContents());
+    }
+}


### PR DESCRIPTION
This pull request refactors the HTTP request body handling in the codebase to use a unified abstraction, `BodyPayloadContract`, and introduces dedicated interfaces and implementations for various body payload types (string, JSON, iterable, resource, and URL-encoded). It also removes legacy methods for setting and retrieving request bodies in favor of this new approach, resulting in a more flexible and extensible system for handling HTTP request bodies.